### PR TITLE
Melhoria detalhe criterios negativos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![PHP API](https://img.shields.io/badge/PHP-Support%20for%20TS%20%26%20NTS-blue)
 ![PHP Version](https://img.shields.io/badge/PHP-%3E=8.1-brightgreen)
 ![Status](https://img.shields.io/badge/Status-Stable-brightgreen)
-![AHPd Core](https://img.shields.io/badge/AHPd%20Core-0.1.2-purple)
+![AHPd Core](https://img.shields.io/badge/AHPd%20Core-0.1.3-purple)
 
 **AHPd** is a **100% objective, multi-criteria decision-making system**, representing a **modern, data-driven evolution** of the classic *Analytic Hierarchy Process (AHP)* method.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+# Changelog
+
+# 1.0.2 - 2025-10-24
+
+### Changed
+
+* **Criteria Display:** The **normalization logic for breakdown data** (`alternatives_contribution.by_criteria`) has been improved. It now applies a two-step normalization that ensures that:
+1. The lowest negative value is correctly mapped to `min` (e.g., **0**).
+2. The **sum of normalized values** for each alternative is always equal to the `total sum` (e.g., **100**).
+
+This ensures a better and more consistent display of criteria performance, especially those derived from original data that include negative values.
+
 ## Changelog
 
 # 1.0.0 - 2025-10-16

--- a/php-extension/example/finance.json
+++ b/php-extension/example/finance.json
@@ -1,0 +1,17 @@
+{
+    "data": {
+        "criteria": {
+            "net profit USD": "max",
+            "debts %": "min",
+            "portfolio growth %": "max",
+            "return on assets %": "max",
+            "provision for losses USD": "min"
+        },
+        "options": {
+            "Bank 1": [12500000, 3.2, 12.5, 1.8, 450000],
+            "Bank 2": [-500000, 7.9, 0.0, -0.4, 950000],
+            "Bank 3": [8420000, 2.1, 8.3, 1.2, 300000],
+            "Bank 4": [0, 5.0, -1.5, 0.3, 750000]
+        }
+    }
+}

--- a/php-extension/example/finance.php
+++ b/php-extension/example/finance.php
@@ -1,0 +1,99 @@
+<?php
+
+if (!extension_loaded('ahpd')) {
+    throw new \Exception("Extension not loaded");
+}
+use \AHPd\Data;
+
+$json_file = dirname(__FILE__). '/finance.json';
+
+if (!file_exists($json_file)) {
+    throw new \Exception("JSON file not found: {$json_file}");
+}
+
+$json_data = file_get_contents($json_file);
+$config = json_decode($json_data, true);
+
+if (json_last_error() !== JSON_ERROR_NONE) {
+    throw new \Exception("JSON decode error: " . json_last_error_msg());
+}
+
+$data = $config['data'];
+$criteria_preferences = $data['criteria'];
+$options_data = $data['options'];
+
+
+$ahp = new Data;
+
+$ahp->setCriteria($criteria_preferences);
+
+$criteria_names = array_keys($criteria_preferences);
+
+foreach ($options_data as $option_name => $values) {
+    $mapped_params = array_combine($criteria_names, $values);
+
+    $ahp->setOption($option_name, $mapped_params);
+}
+
+$results = $ahp->run(
+    rank: true,
+    contribution_global: true,
+    contribution_detailed: true
+);
+
+$criteria_data = $results['contribution']['alternatives_contribution']['by_criteria'];
+$rank_data = $results['rank'];
+$criteria_weights = $results['contribution']['criteria_weights']; // NOVO: Captura os pesos!
+
+$rank_data = array_map(function($value) {
+    return $value * 100;
+}, $rank_data);
+
+$bank = array_keys($criteria_data);
+$criteria_names = array_keys(current($criteria_data));
+$datasets = [];
+$colors = ['#1abc9c', '#3498db', '#9b59b6', '#e67e22', '#e74c3c'];
+$color_index = 0;
+
+foreach ($criteria_names as $crit) {
+    $data_values = [];
+    foreach ($bank as $b) {
+        $data_values[] = $criteria_data[$b][$crit];
+    }
+    
+    $datasets[] = [
+        'label' => $crit,
+        'data' => $data_values,
+        'backgroundColor' => $colors[$color_index % count($colors)],
+        'rank_total' => $rank_data, 
+    ];
+    $color_index++;
+}
+
+// NOVO: Adiciona os pesos ao objeto principal de dados
+$chart_data = [
+    'labels' => $bank,
+    'datasets' => $datasets,
+    'criteria_weights' => $criteria_weights, // CHAVE PARA O NOVO GRÁFICO!
+];
+
+// -----------------------------------------------------------------------------
+// INJEÇÃO NO TEMPLATE E SALVAMENTO (Mesmo código de antes)
+// -----------------------------------------------------------------------------
+
+$json_string = json_encode($chart_data, JSON_PRETTY_PRINT);
+$js_code = "CHART_DATA = " . $json_string . ";"; 
+
+$template_file = 'chart_template.html';
+$output_file = 'index_finance.html';
+$placeholder = '// CHART_DATA_PLACEHOLDER';
+
+if (!file_exists($template_file)) {
+    die("Error: The template file '{$template_file}' was not found.\n");
+}
+
+$template_content = file_get_contents($template_file);
+$final_html = str_replace($placeholder, $js_code, $template_content);
+file_put_contents($output_file, $final_html);
+
+echo "Final HTML report generated successfully! Open '{$output_file}' in your browser.\n";

--- a/php-extension/example/index_finance.html
+++ b/php-extension/example/index_finance.html
@@ -71,7 +71,103 @@
     <script>
         var CHART_DATA; 
         
-        // CHART_DATA_PLACEHOLDER
+        CHART_DATA = {
+    "labels": [
+        "Bank 1",
+        "Bank 2",
+        "Bank 3",
+        "Bank 4"
+    ],
+    "datasets": [
+        {
+            "label": "debts %",
+            "data": [
+                19.07869522332401,
+                32.51452303086958,
+                20.032881617310533,
+                23.03722250978845
+            ],
+            "backgroundColor": "#1abc9c",
+            "rank_total": {
+                "Bank 1": 55.41566713925148,
+                "Bank 2": -1.6826168573188902,
+                "Bank 3": 41.9936800319154,
+                "Bank 4": 4.273269686152023
+            }
+        },
+        {
+            "label": "net profit USD",
+            "data": [
+                20.549666244155496,
+                14.670556740832938,
+                19.95763444917969,
+                17.83702105673168
+            ],
+            "backgroundColor": "#3498db",
+            "rank_total": {
+                "Bank 1": 55.41566713925148,
+                "Bank 2": -1.6826168573188902,
+                "Bank 3": 41.9936800319154,
+                "Bank 4": 4.273269686152023
+            }
+        },
+        {
+            "label": "portfolio growth %",
+            "data": [
+                20.707083995949677,
+                17.83702105740172,
+                20.048719587435663,
+                15.583273777184814
+            ],
+            "backgroundColor": "#9b59b6",
+            "rank_total": {
+                "Bank 1": 55.41566713925148,
+                "Bank 2": -1.6826168573188902,
+                "Bank 3": 41.9936800319154,
+                "Bank 4": 4.273269686152023
+            }
+        },
+        {
+            "label": "provision for losses USD",
+            "data": [
+                19.077023507178442,
+                34.977899170895775,
+                19.995661113548095,
+                22.705646255047533
+            ],
+            "backgroundColor": "#e67e22",
+            "rank_total": {
+                "Bank 1": 55.41566713925148,
+                "Bank 2": -1.6826168573188902,
+                "Bank 3": 41.9936800319154,
+                "Bank 4": 4.273269686152023
+            }
+        },
+        {
+            "label": "return on assets %",
+            "data": [
+                20.587531029392363,
+                0,
+                19.965103232526012,
+                20.836836401247524
+            ],
+            "backgroundColor": "#e74c3c",
+            "rank_total": {
+                "Bank 1": 55.41566713925148,
+                "Bank 2": -1.6826168573188902,
+                "Bank 3": 41.9936800319154,
+                "Bank 4": 4.273269686152023
+            }
+        }
+    ],
+    "criteria_weights": {
+        "debts %": 0.10820844076687969,
+        "net profit USD": 0.2488186717978647,
+        "portfolio growth %": 0.27488154550154764,
+        "provision for losses USD": 0.1026181017550355,
+        "return on assets %": 0.2654732401786726
+    }
+};
 
         const ctx = document.getElementById('rankingChart').getContext('2d');
 


### PR DESCRIPTION
# Changelog

# 1.0.2 - 2025-10-24

### Changed

* **Criteria Display:** The **normalization logic for breakdown data** (`alternatives_contribution.by_criteria`) has been improved. It now applies a two-step normalization that ensures that:
1. The lowest negative value is correctly mapped to `min` (e.g., **0**).
2. The **sum of normalized values** for each alternative is always equal to the `total sum` (e.g., **100**).

This ensures a better and more consistent display of criteria performance, especially those derived from original data that include negative values.